### PR TITLE
Add support for distributing as a .zip file in addition to .tar.gz, increment plugin version number.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy() //not needed for Java plugins
-  compile ("org.kamranzafar:jtar:2.3")
+  compile group: 'org.apache.commons', name: 'commons-compress', version: '1.18'
   // other dependencies that your plugin requires
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
 // Unless overridden in the pluginBundle config DSL, the project version will
 // be used as your plugin version when publishing
-version = "0.2.18"
+version = "0.2.19"
 group = "net.karlmartens.dotnet"
 
 // The configuration example below shows the minimum required properties

--- a/src/main/java/net/karlmartens/dotnet/Distribution.java
+++ b/src/main/java/net/karlmartens/dotnet/Distribution.java
@@ -1,20 +1,25 @@
 package net.karlmartens.dotnet;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.compress.utils.IOUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
-import org.kamranzafar.jtar.TarEntry;
-import org.kamranzafar.jtar.TarOutputStream;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 public class Distribution extends DotnetDefaultTask  {
     private static Logger LOGGER = Logging.getLogger(Distribution.class);
@@ -104,7 +109,7 @@ public class Distribution extends DotnetDefaultTask  {
         }
     }
 
-    private void archive(File file) throws IOException {
+    private void archive(File file) throws IOException, ArchiveException, CompressorException {
         LOGGER.quiet("Bundling {}.", file.toString());
         Path source = file.toPath();
 
@@ -120,43 +125,34 @@ public class Distribution extends DotnetDefaultTask  {
         File targetFile = target.toFile();
         targetFile.createNewFile();
 
-        switch(getExtension().getDistributeAs()) {
-            case(".zip"): //.zip
-                try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(targetFile, false))) {
-                    for (String includedFile : scanner.getIncludedFiles()) {
-                        LOGGER.debug("Adding file {}", includedFile);
-                        File f = source.resolve(includedFile).toFile();
+        try (ArchiveOutputStream out = new ArchiveStreamFactory().createArchiveOutputStream(getExtension().getArchiveAs(), new FileOutputStream(targetFile, false))) {
+            for (String includedFile : scanner.getIncludedFiles()) {
+                LOGGER.debug("Adding file {}", includedFile);
+                File f = source.resolve(includedFile).toFile();
+                out.putArchiveEntry(buildArchiveEntry(f));
+                IOUtils.copy(new FileInputStream(file), out);
+                out.closeArchiveEntry();
+            }
+        }
 
-                        out.putNextEntry(new ZipEntry(f.getName()));
-
-                        addFileToOutputStream(out, f);
-
-                        out.closeEntry();
-                    }
+        if(getExtension().getCompressAs() != null && !getExtension().getCompressAs().isEmpty()) {
+            final String compressedTarget = targetFile.getAbsolutePath() + "." + getExtension().getCompressAs();
+            LOGGER.quiet("Compress {}.", compressedTarget);
+            try (FileOutputStream out = new FileOutputStream(compressedTarget, false)) {
+                CompressorStreamFactory factory = new CompressorStreamFactory();
+                try (CompressorOutputStream compressorStream = factory.createCompressorOutputStream(getExtension().getCompressAs(), out)) {
+                    IOUtils.copy(new FileInputStream(targetFile), compressorStream);
                 }
-                break;
-            default:
-                try (TarOutputStream out = new TarOutputStream(new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(targetFile, false))))) {
-                    for (String includedFile : scanner.getIncludedFiles()) {
-                        LOGGER.debug("Adding file {}", includedFile);
-                        File f = source.resolve(includedFile).toFile();
-
-                        out.putNextEntry(new TarEntry(f, includedFile));
-
-                        addFileToOutputStream(out, f);
-                    }
-                }
-                break;
+            }
         }
     }
 
-    private void addFileToOutputStream(OutputStream out, File f) throws IOException {
-        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(f))) {
-            int count;
-            byte data[] = new byte[2048];
-            while ((count = in.read(data)) != -1) {
-                out.write(data, 0, count);
-            }
+    private ArchiveEntry buildArchiveEntry(File f) {
+        switch(getExtension().getArchiveAs()) {
+            case(ArchiveStreamFactory.ZIP):
+                return new ZipArchiveEntry(f.getName());
+            default:
+                return new TarArchiveEntry(f);
         }
     }
 
@@ -177,7 +173,7 @@ public class Distribution extends DotnetDefaultTask  {
             filename.append(_version);
         }
 
-        filename.append(getExtension().getDistributeAs());
+        filename.append("." + getExtension().getArchiveAs());
 
         Path baseDir = getOutputDir().toPath();
         return baseDir.resolve(filename.toString());

--- a/src/main/java/net/karlmartens/dotnet/DotnetExtension.java
+++ b/src/main/java/net/karlmartens/dotnet/DotnetExtension.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 public class DotnetExtension {
 
     private String _configuration = null;
+    private String _distributeAs = ".tar.gz"; // Options: .tar.gz, .zip
     private String _dotnetHome = null;
     private String _solution = "";
     private String _projectPattern = "**/*.csproj";
@@ -25,6 +26,14 @@ public class DotnetExtension {
 
     public void setConfiguration(String configuration) {
         _configuration = configuration;
+    }
+
+    public String getDistributeAs() {
+        return _distributeAs;
+    }
+
+    public void setDistributeAs(String distributeAs) {
+        _distributeAs = distributeAs;
     }
 
     public String getFramework() {

--- a/src/main/java/net/karlmartens/dotnet/DotnetExtension.java
+++ b/src/main/java/net/karlmartens/dotnet/DotnetExtension.java
@@ -1,12 +1,16 @@
 package net.karlmartens.dotnet;
 
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.gradle.internal.impldep.org.apache.commons.compress.compressors.CompressorStreamFactory;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class DotnetExtension {
 
     private String _configuration = null;
-    private String _distributeAs = ".tar.gz"; // Options: .tar.gz, .zip
+    private String _archiveAs = ArchiveStreamFactory.TAR;
+    private String _compressAs = CompressorStreamFactory.GZIP;
     private String _dotnetHome = null;
     private String _solution = "";
     private String _projectPattern = "**/*.csproj";
@@ -28,12 +32,20 @@ public class DotnetExtension {
         _configuration = configuration;
     }
 
-    public String getDistributeAs() {
-        return _distributeAs;
+    public String getArchiveAs() {
+        return _archiveAs;
     }
 
-    public void setDistributeAs(String distributeAs) {
-        _distributeAs = distributeAs;
+    public void setArchiveAs(String archiveAs) {
+        _archiveAs = archiveAs;
+    }
+
+    public String getCompressAs() {
+        return _compressAs;
+    }
+
+    public void setCompressAs(String compressAs) {
+        _compressAs = compressAs;
     }
 
     public String getFramework() {


### PR DESCRIPTION
Added outputting a distribution as a .zip file since AWS Lambda expects the payload to be in that format.